### PR TITLE
82 create account information tab

### DIFF
--- a/cs_app/templates/directions.html
+++ b/cs_app/templates/directions.html
@@ -478,10 +478,47 @@
                             </ul>
                         </div>
                     </div>
-                    <div
-                        id="d1-2-9"
-                        class="outlineP slide doubleSlide down"
-                    ></div>
+                    <div id="d1-2-9" class="outlineP slide doubleSlide down">
+                        <h2>Place Holder</h2>
+                        <div class="explanation">
+                            <p>
+                                Mutatio rationum est processus ubi tu potes
+                                mutare nomina, emailes, vel codices accedentis
+                                in tua conto. Hoc operatio utile est ut tuas
+                                actiones et consilium tutum et accurate
+                                reserces. Tamen, cura debetur cum mutationes,
+                                quia post confirmationem non revertentur!
+                            </p>
+                        </div>
+                        <div class="list">
+                            <h4>Place Holder</h4>
+                            <ul>
+                                <li>
+                                    <strong>Place Holder 1</strong> - Mutatio
+                                    rationum est processus ubi possis mutare
+                                    nomina, emailes, et codices accedentis in
+                                    conto tuo. Cura maxima habenda est, quia
+                                    mutationes post confirmationem non possunt
+                                    reverti.
+                                </li>
+                                <li>
+                                    <strong>Place Holder 2</strong> - Mutatio
+                                    rationum in conto te adiuvat emendare
+                                    nomina, emailes, et codices accedentis.
+                                    Securitati et fidelitati tuarum actionum
+                                    conducit, sed mutationes post confirmationem
+                                    permanentes sunt.
+                                </li>
+                                <li>
+                                    <strong>Place Holder 3</strong> - Emendatio
+                                    rationum in conto te permitit configurare
+                                    nomina, emailes, et codices accedentis. Cura
+                                    maxima habenda est, quia mutationes post
+                                    confirmationem firmatae sunt.
+                                </li>
+                            </ul>
+                        </div>
+                    </div>
                 </div>
             </div>
         </div>

--- a/cs_app/templates/directions.html
+++ b/cs_app/templates/directions.html
@@ -97,7 +97,7 @@
                                 </li>
                                 <li>
                                     <strong>Database Driver</strong> - This is
-                                    the set od protocols used to control the
+                                    the set of protocols used to control the
                                     databse
                                 </li>
                                 <li>

--- a/cs_app/templates/directions.html
+++ b/cs_app/templates/directions.html
@@ -439,10 +439,45 @@
                             </ul>
                         </div>
                     </div>
-                    <div
-                        id="d1-2-8"
-                        class="outlineB slide doubleSlide up"
-                    ></div>
+                    <div id="d1-2-8" class="outlineB slide doubleSlide up">
+                        <h2>Account Information Fields</h2>
+                        <div class="explanation">
+                            <p>
+                                Your account information consists of three
+                                crucial fields: first and last name, email, and
+                                password. Each field has specific requirements
+                                and formats, detailed below. Please exercise
+                                caution when making changes, as once confirmed,
+                                they cannot be reverted.
+                            </p>
+                        </div>
+                        <div class="list">
+                            <h4>Common Messages</h4>
+                            <ul>
+                                <li>
+                                    <strong>First and Last Name</strong> - Your
+                                    first and last name uniquely identify your
+                                    account and serve as additional identifiers
+                                    beyond your username/email. These fields
+                                    accept only alphabetical characters.
+                                </li>
+                                <li>
+                                    <strong>Email</strong> - Your email serves
+                                    both as your username and contact email. It
+                                    must adhere to standard email character
+                                    limitations and maintain the format
+                                    "example@company.com".
+                                </li>
+                                <li>
+                                    <strong>Password</strong> - Your password is
+                                    securely hashed and not stored in plain
+                                    text. It must be at least 8 characters long,
+                                    including at least one special character and
+                                    one number, for enhanced security.
+                                </li>
+                            </ul>
+                        </div>
+                    </div>
                     <div
                         id="d1-2-9"
                         class="outlineP slide doubleSlide down"


### PR DESCRIPTION
# Changes
- Filled out first slide on account information tab
- Filled out the second slide with place holder information to be filled in at a later date
    - There is not enough information to tell the user about account information. A workaround or new feature must be added
- Fixed small spelling error

# Github Effects
- Closes issue #82 