### PR TITLE
Changed min width on .report-date to 3.2rem from 2.9rem

### DIFF
--- a/cs_app/static/css/generate_report_style.css
+++ b/cs_app/static/css/generate_report_style.css
@@ -159,7 +159,7 @@ html {
 
 .report-date {
     width: 25%;
-    min-width: 2.9rem;
+    min-width: 3.2rem;
     max-width: 4.5rem;
     height: 2.5rem;
 }


### PR DESCRIPTION
# Changes
- Changed min width on .report-date from 2.9rem to 3.2rem

## Note
This is a quick fix and the linked issue will remain open. Expect a more permanent solution at a later date.

## Github effects
- None

